### PR TITLE
Also treat "." and "-" as level separators

### DIFF
--- a/mu4e-overview.el
+++ b/mu4e-overview.el
@@ -269,7 +269,11 @@ passed to CALLBACK will be 0."
                        :name parent-name
                        :maildir nil))
                 (push parent-folder folders))
-              (push folder (mu4e-overview-folder-children parent-folder))
+              (setf (mu4e-overview-folder-children parent-folder)
+                    (cl-sort
+                     (cons folder
+                           (mu4e-overview-folder-children parent-folder))
+                     #'string< :key #'mu4e-overview-folder-name))
               (setq folders (delete folder folders)))))))
 
     (setq mu4e-overview-folders folders)))

--- a/mu4e-overview.el
+++ b/mu4e-overview.el
@@ -335,4 +335,7 @@ The available keybindings are:
     (pop-to-buffer (current-buffer))))
 
 (provide 'mu4e-overview)
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; End:
 ;;; mu4e-overview.el ends here


### PR DESCRIPTION
In my case maildirs are named for example `INBOX.emacs-devel` and `INBOX.Sent`. While I could replace the `-` with `/`, I have no control over the separator that follows `INBOX` (or that `Sent` is a child of `INBOX`. We could add an option to let the user specify the separators.

Note that this also strips the separator before children--that looks better when a variety of different separators are used. This could be made optional if you think that is necessary.

This also orders each set of siblings.