### PR TITLE
Use the overview as replacement for the official main buffer

### DIFF
--- a/mu4e-overview.el
+++ b/mu4e-overview.el
@@ -327,6 +327,9 @@ If argument N is provided, go to Nth previous unread folder."
 
 (defvar mu4e-overview-mode-map
   (let ((map (copy-keymap button-buffer-map)))
+    (set-keymap-parent map mu4e-main-mode-map)
+    (define-key map "q" #'bury-buffer)
+    (define-key map "?" #'mu4e~main-menu)
     (define-key map "n" #'next-line)
     (define-key map "]" #'mu4e-overview-next-unread-folder)
     (define-key map "p" #'previous-line)

--- a/mu4e-overview.el
+++ b/mu4e-overview.el
@@ -353,7 +353,7 @@ The available keybindings are:
   (with-current-buffer (get-buffer-create "*mu4e overview*")
     (mu4e-overview-mode)
     (mu4e-overview-update)
-    (pop-to-buffer (current-buffer))))
+    (display-buffer (current-buffer))))
 
 (provide 'mu4e-overview)
 ;; Local Variables:


### PR DESCRIPTION
This makes it unnecessary to go back to the `mu4e`'s "main" buffer by making the same commands available in our "overview" buffer.

Additionally we allow setting up buffers the way `mu4e` does it for its own buffers, but without actually changing the default behavior. Some user configuration is still necessary.

There is a third part to this: changing `mu4e~headers-quit-buffer` to *not* call `mu4e~main-view`. If this function is not called then we return the previous buffer, which in our case is the overview buffer. I'll open a pr about that in the `mu4e` repository.

----

I find the above quite essential, but since you have not done any of that yourself, I was wondering what *your* workflow is. How do run `mu4e-update-mail-and-index` for example?