### PR TITLE
Start mu4e process if necessary

### DIFF
--- a/mu4e-overview.el
+++ b/mu4e-overview.el
@@ -347,6 +347,8 @@ The buffer shows a hierarchy of maildirs used by `mu4e'.
 The available keybindings are:
 \\{mu4e-overview-mode-map}"
   (interactive)
+  (unless mu4e~server-props
+    (mu4e~start))
   (with-current-buffer (get-buffer-create "*mu4e overview*")
     (mu4e-overview-mode)
     (mu4e-overview-update)


### PR DESCRIPTION
Beginning with mu4e v1.3.7 we have to do this or we get an
error asking use whether we forgot to start the process.