### PR TITLE
mu4e-overview.el (mu4e-overview): Start mu4e process properly

### DIFF
--- a/mu4e-overview.el
+++ b/mu4e-overview.el
@@ -347,8 +347,9 @@ The buffer shows a hierarchy of maildirs used by `mu4e'.
 The available keybindings are:
 \\{mu4e-overview-mode-map}"
   (interactive)
-  (unless mu4e~server-props
-    (mu4e~start))
+  (mu4e~start 'mu4e-overview-internal))
+
+(defun mu4e-overview-internal ()
   (with-current-buffer (get-buffer-create "*mu4e overview*")
     (mu4e-overview-mode)
     (mu4e-overview-update)


### PR DESCRIPTION
Fixes a74874455756c84e5c152fd3f25f3c3746868902, which succeeded in
starting the process but then did not show the overview because we
failed to use the callback to do so.

Sorry for the failed first attempt.  This time around I have tested properly.