### PR TITLE
trim whitespace/newline first for output because of wc

### DIFF
--- a/mu4e-overview.el
+++ b/mu4e-overview.el
@@ -194,8 +194,9 @@ passed to CALLBACK will be 0."
            process
            (lambda (proc _status)
              (unless (process-live-p proc)
+               (setq output (string-trim output))
                (save-match-data
-                 (when (string-match "^\\([0-9]+\\)\n$" output)
+                 (when (string-match "^\\([0-9]+\\)$" output)
                    (setq count (string-to-number
                                 (match-string 1 output)))))
                (if unread-only


### PR DESCRIPTION
I find that `wc` might prepend some space in the output like the following.
```
❯ mu find -f p 'maildir:/.../Archive' | wc -l
       7
```
Which makes the `(string-match "^\\([0-9]+\\)$" output)` return nil.

To solve this, I trim the output first.

BSD wc (on macOS) is the culprit, GNU wc will not prepend the space.

Maybe it's the root cause for #8 .